### PR TITLE
Include HttpService trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,16 @@ pub mod server;
 mod body;
 mod flush;
 mod recv_body;
+mod service;
 
 pub use body::{Body, BoxBody, UnsyncBoxBody};
 pub use client::Client;
 pub use recv_body::{RecvBody, Data};
 pub use server::Server;
+pub use service::HttpService;
+
+mod sealed {
+    /// Private trait to this crate to prevent traits from being implemented in
+    /// downstream crates.
+    pub trait Sealed {}
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,0 +1,48 @@
+use Body;
+
+use http::{Request, Response};
+use futures::{Future, Poll};
+use tower::Service;
+
+/// An HTTP (2.0) service that backs the gRPC client
+///
+/// This is not intended to be implemented directly. Instead, it is a trait
+/// alias of sorts. Implement the `tower::Service` trait using `http::Request`
+/// and `http::Response` types.
+pub trait HttpService: ::sealed::Sealed {
+    type RequestBody: Body;
+    type ResponseBody: Body;
+    type Error;
+    type Future: Future<Item = Response<Self::ResponseBody>, Error = Self::Error>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error>;
+
+    fn call(&mut self, request: Request<Self::RequestBody>) -> Self::Future;
+}
+
+impl<T, B1, B2> HttpService for T
+where T: Service<Request = Request<B1>,
+                Response = Response<B2>>,
+      B1: Body,
+      B2: Body,
+{
+    type RequestBody = B1;
+    type ResponseBody = B2;
+    type Error = T::Error;
+    type Future = T::Future;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        Service::poll_ready(self)
+    }
+
+    fn call(&mut self, request: Request<Self::RequestBody>) -> Self::Future {
+        Service::call(self, request)
+    }
+}
+
+impl<T, B1, B2> ::sealed::Sealed for T
+where T: Service<Request = Request<B1>,
+                Response = Response<B2>>,
+      B1: Body,
+      B2: Body,
+{}

--- a/src/service.rs
+++ b/src/service.rs
@@ -4,19 +4,28 @@ use http::{Request, Response};
 use futures::{Future, Poll};
 use tower::Service;
 
-/// An HTTP (2.0) service that backs the gRPC client
+/// An HTTP service
 ///
 /// This is not intended to be implemented directly. Instead, it is a trait
-/// alias of sorts. Implement the `tower::Service` trait using `http::Request`
+/// alias of sorts. Implements the `tower::Service` trait using `http::Request`
 /// and `http::Response` types.
 pub trait HttpService: ::sealed::Sealed {
+    /// Request payload.
     type RequestBody: Body;
+
+    /// Response payload.
     type ResponseBody: Body;
+
+    /// Errors produced by the service.
     type Error;
+
+    /// The future response value.
     type Future: Future<Item = Response<Self::ResponseBody>, Error = Self::Error>;
 
+    /// Returns `Ready` when the service is able to process requests.
     fn poll_ready(&mut self) -> Poll<(), Self::Error>;
 
+    /// Process the request and return the response asynchronously.
     fn call(&mut self, request: Request<Self::RequestBody>) -> Self::Future;
 }
 


### PR DESCRIPTION
This is not intended to be implemented by the end user. Instead, it is a trait alias of sorts, allowing users to directly reference and add bounds to the request and response body types.