### PR TITLE
Use correct path in server example

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -47,8 +47,7 @@ impl Body for RspBody {
     }
 }
 
-//const ROOT: &'static str = "/";
-const ROOT: &'static str = "/helloworld.Greeter/SayHello";
+const ROOT: &'static str = "/";
 
 #[derive(Debug)]
 struct Svc;


### PR DESCRIPTION
Currently the server example serves requests on
`/helloworld.Greeter/SayHello`, but client accesses to `/`. So, the
example always returns `404 Not Found` error.

This patch fixes the issue by making a tiny change to add the uri path
`/helloworld.Greeter/SayHello` to client request in example.