### PR TITLE
Implement std::error::Error for tower-h2 error types

### DIFF
--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -154,9 +154,21 @@ where
 
 // ===== impl ConnectError =====
 
-impl<T> fmt::Display for ConnectError<T> where T: Error {
+impl<T> fmt::Display for ConnectError<T> 
+where 
+    T: Error 
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}: {:?}", self.description(), self.cause())
+        match *self {
+            ConnectError::Connect(ref why) => write!(f, 
+                "Error attempting to establish underlying session layer: {}",
+                why
+            ),
+            ConnectError::Handshake(ref why) =>  write!(f, 
+                "Error while performing HTTP/2.0 handshake: {}",
+                why,
+            ),
+        }
     }
 }
 
@@ -167,9 +179,9 @@ where
     fn description(&self) -> &str {
         match *self {
             ConnectError::Connect(_) => 
-                "Error while attempting to establish underlying session layer",
+                "error attempting to establish underlying session layer",
             ConnectError::Handshake(_) => 
-                "Error while performing HTTP/2.0 handshake"
+                "error performing HTTP/2.0 handshake"
         }
     }
 

--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -7,6 +7,8 @@ use h2;
 use http::{Request, Response};
 use tokio_connect;
 
+use std::error::Error;
+use std::fmt;
 use std::marker::PhantomData;
 
 /// Establishes an H2 client connection.
@@ -146,6 +148,35 @@ where
             let handshake = Handshake::new(io, executor, &self.builder);
 
             self.state = State::Handshake(handshake);
+        }
+    }
+}
+
+// ===== impl ConnectError =====
+
+impl<T> fmt::Display for ConnectError<T> where T: Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}: {:?}", self.description(), self.cause())
+    }
+}
+
+impl<T> Error for ConnectError<T>
+where
+    T: Error,
+{
+    fn description(&self) -> &str {
+        match *self {
+            ConnectError::Connect(_) => 
+                "Error while attempting to establish underlying session layer",
+            ConnectError::Handshake(_) => 
+                "Error while performing HTTP/2.0 handshake"
+        }
+    }
+
+    fn cause(&self) -> Option<&Error> {
+        match *self {
+            ConnectError::Connect(ref why) => Some(why),
+            ConnectError::Handshake(ref why) => Some(why),
         }
     }
 }

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -255,9 +255,9 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.kind {
             Kind::Inner(ref h2) => 
-                write!(f, "error caused by underlying HTTP/2 error: {}", h2),
+                write!(f, "Error caused by underlying HTTP/2 error: {}", h2),
             Kind::Spawn => 
-                write!(f, "error spawning background task"),
+                write!(f, "Error spawning background task"),
         }
     }
 }

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -11,6 +11,7 @@ use http::{self, Request, Response};
 use tower::Service;
 use tokio_io::{AsyncRead, AsyncWrite};
 
+use std::{error, fmt};
 use std::marker::PhantomData;
 
 /// Exposes a request/response API on an h2 client connection..
@@ -250,10 +251,75 @@ impl From<h2::Reason> for Error {
     }
 }
 
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.kind {
+            Kind::Inner(ref h2) => 
+                write!(f, "error caused by underlying HTTP/2 error: {}", h2),
+            Kind::Spawn => 
+                write!(f, "error spawning background task"),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn cause(&self) -> Option<&error::Error> {
+        if let Kind::Inner(ref h2) = self.kind {
+            Some(h2)
+        } else {
+            None
+        }
+    }
+
+    fn description(&self) -> &str {
+        match self.kind {
+            Kind::Inner(ref h2) => h2.description(),
+            Kind::Spawn => "error spawning worker task"
+        }
+    }
+
+}
+
 // ===== impl HandshakeError =====
 
 impl From<h2::Error> for HandshakeError {
     fn from(src: h2::Error) -> Self {
         HandshakeError::Proto(src)
     }
+}
+
+impl fmt::Display for HandshakeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            HandshakeError::Proto(ref h2) =>
+                write!(f, 
+                    "An error occurred while attempting to perform the HTTP/2 \
+                    handshake: {}", 
+                    h2),
+            HandshakeError::Execute =>
+                write!(f, 
+                    "An error occurred while attempting to execute a worker \
+                     task."),
+        }
+    }
+}
+
+impl error::Error for HandshakeError {
+    fn cause(&self) -> Option<&error::Error> {
+        if let HandshakeError::Proto(ref h2) = *self {
+            Some(h2)
+        } else {
+            None
+        }
+    }
+
+    fn description(&self) -> &str {
+        match *self {
+            HandshakeError::Proto(_) =>
+                "error attempting to perform HTTP/2 handshake",
+            HandshakeError::Execute =>
+                "error attempting to execute a worker task",
+        }
+    }
+
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -353,10 +353,17 @@ where
     S::Error: StdError,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if let Some(ref cause) = self.cause() {
-            write!(f, "{}: {}", self.description(), cause)
-        } else {
-            write!(f, "{}", self.description())
+        match *self {
+            Error::Handshake(ref why) => 
+                write!(f, "Error occurred during HTTP/2.0 handshake: {}", why),
+            Error::Protocol(ref why) => 
+                write!(f, "Error produced by HTTP/2.0 stream: {}", why),
+            Error::NewService(ref why) =>
+                write!(f, "Error occurred while obtaining service: {}", why),
+            Error::Service(ref why) =>
+                write!(f, "Error returned by service: {}", why),
+            Error::Execute => 
+                write!(f, "Error occurred while attempting to spawn a task"),
         }
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -8,10 +8,7 @@ use http::{self, Request, Response};
 use tokio_io::{AsyncRead, AsyncWrite};
 use tower::{NewService, Service};
 
-use std::fmt;
-// XXX: alternatively, we could rename the `Error` struct in this module to 
-//      avoid renaming this import.
-use std::error::Error as StdError;
+use std::{error, fmt};
 use std::marker::PhantomData;
 
 /// Attaches service implementations to h2 connections.
@@ -346,11 +343,11 @@ where S: NewService,
 
 impl<S> fmt::Display for Error<S>
 where 
-    Error<S>: StdError,
+    Error<S>: error::Error,
     S: NewService,
     S: fmt::Debug,
-    S::InitError: StdError,
-    S::Error: StdError,
+    S::InitError: error::Error,
+    S::Error: error::Error,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
@@ -368,14 +365,14 @@ where
     }
 }
 
-impl<S> StdError for Error<S>
+impl<S> error::Error for Error<S>
 where 
     S: NewService,
     S: fmt::Debug,
-    S::InitError: StdError,
-    S::Error: StdError,
+    S::InitError: error::Error,
+    S::Error: error::Error,
 {
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&error::Error> {
         match *self {
             Error::Handshake(ref why) => Some(why),
             Error::Protocol(ref why) => Some(why),


### PR DESCRIPTION
Closes #15. Also likely a prerequisite for https://github.com/tower-rs/tower-grpc/issues/6#issuecomment-355347465.