### PR TITLE
Add basic Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: rust
+sudo: false
+
+cache: cargo
+
+matrix:
+  include:
+    - rust: stable
+    - rust: beta
+    - rust: nightly
+
+script:
+  - cargo test
+
+notifications:
+  email:
+on_success: never


### PR DESCRIPTION
This should at least be enough to stop the CI build from breaking; if we want additional CI steps, we can add them in further PRs.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>