### PR TITLE
Update log and env_logger dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ bytes = "0.4"
 futures = "0.1"
 h2 = "0.1"
 http = "0.1"
-log = "0.3"
+log = "0.4"
 tokio-core = "0.1"
 tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
 tokio-io = "0.1"
 tower = { git = "https://github.com/tower-rs/tower" }
 
 [dev-dependencies]
-env_logger = "^0.4.3"
+env_logger = { version = "^0.5", default-features = false }
 string = { git = "https://github.com/carllerche/string" }


### PR DESCRIPTION
Reduce the chances that a tower-h2-based application will require
multiple versions of log and/or env_logger. Also avoid automatically
enabling the regex feature of env_logger to avoid unnecessarily
pulling in that dependency.

Signed-off-by: Brian Smith <brian@briansmith.org>