### PR TITLE
Improve GOAWAY sending of Server Connection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 [dependencies]
 bytes = "0.4"
 futures = "0.1"
-h2 = { git = "https://github.com/carllerche/h2" } #"0.1"
+h2 = "0.1.4"
 http = "0.1"
 log = "0.4"
 tokio-core = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 [dependencies]
 bytes = "0.4"
 futures = "0.1"
-h2 = "0.1"
+h2 = { git = "https://github.com/carllerche/h2" } #"0.1"
 http = "0.1"
 log = "0.4"
 tokio-core = "0.1"

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -358,7 +358,6 @@ where T: AsyncRead + AsyncWrite,
     }
 }
 
-
 // ===== impl Modify =====
 
 impl<T> Modify for T
@@ -506,5 +505,5 @@ where
             Error::Execute => "error occurred while attempting to spawn a task",
         }
     }
-
 }
+

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -321,11 +321,11 @@ where T: AsyncRead + AsyncWrite,
             _ => unreachable!(),
         };
 
-        // We only break out of the loop on a service error, which means we
+        // We only break out of the loop on an error, which means we
         // should transition to GOAWAY.
         match mem::replace(&mut self.state, State::Done) {
             State::Ready { mut connection, .. } => {
-                connection.abrupt_shutdown(Reason::INTERNAL_ERROR);
+                connection.graceful_shutdown();
 
                 self.state = State::GoAway {
                     connection,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -90,7 +90,6 @@ where B: Body,
 }
 
 /// Error produced by a `Connection`.
-#[derive(Debug)]
 pub enum Error<S>
 where S: NewService,
 {
@@ -455,13 +454,36 @@ where S: NewService,
     }
 }
 
+impl<S> fmt::Debug for Error<S>
+where
+    S: NewService,
+    S::InitError: fmt::Debug,
+    S::Error: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::Handshake(ref why) => f.debug_tuple("Handshake")
+                .field(why)
+                .finish(),
+            Error::Protocol(ref why) => f.debug_tuple("Protocol")
+                .field(why)
+                .finish(),
+            Error::NewService(ref why) => f.debug_tuple("NewService")
+                .field(why)
+                .finish(),
+            Error::Service(ref why) => f.debug_tuple("Service")
+                .field(why)
+                .finish(),
+            Error::Execute => f.debug_tuple("Execute").finish(),
+        }
+    }
+}
+
 impl<S> fmt::Display for Error<S>
 where
-    Error<S>: error::Error,
     S: NewService,
-    S: fmt::Debug,
-    S::InitError: error::Error,
-    S::Error: error::Error,
+    S::InitError: fmt::Display,
+    S::Error: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
@@ -482,7 +504,6 @@ where
 impl<S> error::Error for Error<S>
 where
     S: NewService,
-    S: fmt::Debug,
     S::InitError: error::Error,
     S::Error: error::Error,
 {


### PR DESCRIPTION
- If there is an `Err` returned from `Service::poll_ready`, an abrupt shutdown is started, and allowed to flush before returning the error.
- If the `Service` isn't ready, the `Connection` is still polled (via `poll_close`) so that internal HTTP2 connection state still functions.
- Adds `graceful_shutdown` to `tower_h2::server::Connection`, to start a graceful HTTP2 shutdown.
