### PR TITLE
Update examples to compile with new Tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ futures = "0.1"
 h2 = "0.1.4"
 http = "0.1"
 log = "0.4"
-tokio-core = "0.1"
 tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
 tokio-io = "0.1"
 tower-service = { git = "https://github.com/tower-rs/tower" }
@@ -28,3 +27,4 @@ tower-service = { git = "https://github.com/tower-rs/tower" }
 [dev-dependencies]
 env_logger = { version = "^0.5", default-features = false }
 string = { git = "https://github.com/carllerche/string" }
+tokio = "0.1"

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -26,7 +26,7 @@ pub struct Conn(SocketAddr);
 fn main() {
     drop(env_logger::init());
 
-    let rt = Runtime::new().unwrap();
+    let mut rt = Runtime::new().unwrap();
     let executor = rt.executor();
 
     let addr = "[::1]:8888".parse().unwrap();
@@ -58,7 +58,8 @@ fn main() {
         .map(|_| println!("done"))
         .map_err(|e| println!("error: {:?}", e));
 
-    tokio::run(done);
+    rt.spawn(done);
+    rt.shutdown_on_idle().wait().unwrap();
 }
 
 /// Avoids overflowing max concurrent streams

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -5,15 +5,15 @@ extern crate h2;
 extern crate http;
 #[macro_use]
 extern crate log;
-extern crate tokio_core;
+extern crate tokio;
 extern crate tower_h2;
 extern crate tower_service;
 
 use bytes::Bytes;
 use futures::*;
 use http::Request;
-use tokio_core::net::TcpListener;
-use tokio_core::reactor::Core;
+use tokio::net::TcpListener;
+use tokio::runtime::Runtime;
 use tower_h2::{Body, Server, RecvBody};
 use tower_service::{NewService, Service};
 
@@ -96,16 +96,16 @@ impl NewService for NewSvc {
 fn main() {
     drop(env_logger::init());
 
-    let mut core = Core::new().unwrap();
-    let reactor = core.handle();
+    let mut rt = Runtime::new().unwrap();
+    let reactor = rt.executor();
 
     let h2 = Server::new(NewSvc, Default::default(), reactor.clone());
 
     let addr = "[::1]:8888".parse().unwrap();
-    let bind = TcpListener::bind(&addr, &reactor).expect("bind");
+    let bind = TcpListener::bind(&addr).expect("bind");
 
     let serve = bind.incoming()
-        .fold((h2, reactor), |(h2, reactor), (sock, _)| {
+        .fold((h2, reactor), |(h2, reactor), sock| {
             if let Err(e) = sock.set_nodelay(true) {
                 return Err(e);
             }
@@ -114,7 +114,12 @@ fn main() {
             reactor.spawn(serve.map_err(|e| error!("h2 error: {:?}", e)));
 
             Ok((h2, reactor))
-        });
+        })
+        .map_err(|e| error!("serve error: {:?}", e))
+        .map(|_| {})
+        ;
 
-    core.run(serve).unwrap();
+    tokio::run(serve);
+    rt.shutdown_now()
+        .wait().unwrap();
 }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -119,7 +119,7 @@ fn main() {
         .map(|_| {})
         ;
 
-    tokio::run(serve);
-    rt.shutdown_now()
+    rt.spawn(serve);
+    rt.shutdown_on_idle()
         .wait().unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@ extern crate http;
 #[macro_use]
 extern crate log;
 extern crate tokio_connect;
-extern crate tokio_core;
 extern crate tokio_io;
 extern crate tower_service;
 


### PR DESCRIPTION
This PR updates the `tower-h2` examples to compile with the new Tokio. It's necessary for the examples to compile correctly, or otherwise downstream crates that depend on this crate will not be able to compile. 

No functional changes in the library itself were necessary besides changing the name of the imported `tokio` crate in `lib.rs`.

