### PR TITLE
check for RST_STREAMs on SendResponse and SendStream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 [dependencies]
 bytes = "0.4"
 futures = "0.1"
-h2 = "0.1.4"
+h2 = "0.1.9"
 http = "0.1"
 log = "0.4"
 tokio-core = "0.1"


### PR DESCRIPTION
While waiting for a server response future or body to complete, make sure to listen for `RST_STREAM`s that might be sent by the client, and cancel the future if received.

Closes #29 