### PR TITLE
Clarify MIT license

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = [
   "Carl Lerche <me@carllerche.com>",
   "Oliver Gould <ver@buoyant.io>",
 ]
+license = "MIT"
 description = "Provides an HTTP/2.0 Tower Service"
 publish = false
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2017 tower-h2 authors.
+Copyright (c) 2018 tower-h2 authors.
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/README.md
+++ b/README.md
@@ -14,3 +14,13 @@ development and there has not yet been any focus on documentation (because you
 shouldn't be using it yet!).
 
 Also, at some point, this will be folded into Hyper.
+
+## License
+
+This project is licensed under the [MIT license](LICENSE).
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in `tower-h2` by you, shall be licensed as MIT, without any
+additional terms or conditions.


### PR DESCRIPTION
Call out MIT license in the README and Cargo.toml.