### PR TITLE
Update `tokio` dependency in `test` crate

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -10,7 +10,7 @@ futures = "0.1.21"
 h2 = "0.1.4"
 h2-support = { git = "https://github.com/carllerche/h2" }
 http = "0.1.5"
-tokio = "0.1.5"
+tokio = "0.1.7"
 tower-h2 = { path = ".." }
 tower-service = { git = "https://github.com/tower-rs/tower" }
 tower-util = { git = "https://github.com/tower-rs/tower" }


### PR DESCRIPTION
Before this change, the tests would fail to compile due to a dependency
conflict between the version `tokio-timer` required by `tokio` 0.1.6,
which the test crate depends on, and the version of `tokio-timer` which
the `tower-balance` crate depends on:

```
➜ cargo test -p test
    Updating registry `https://github.com/rust-lang/crates.io-index`
    Updating git repository `https://github.com/tower-rs/tower`
    Updating git repository `https://github.com/carllerche/h2`
error: failed to select a version for `tokio-timer`.
    ... required by package `tokio v0.1.6`
    ... which is depended on by `tests v0.1.0 (file:///Users/eliza/Code/tower-h2/tests)`
versions that meet the requirements `= 0.2.3` are: 0.2.3

all possible versions conflict with previously selected packages.

  previously selected package `tokio-timer v0.2.4`
    ... which is depended on by `tower-balance v0.1.0 (https://github.com/tower-rs/tower#20fb04e3)`
    ... which is depended on by `tower-h2-balance v0.1.0 (file:///Users/eliza/Code/tower-h2/tower-balance)`

failed to select a version for `tokio-timer` which could resolve this conflict
```

After updating the `tokio` version, the tests compile successfully.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>