### PR TITLE
Add `stream_id` accessor to `RecvBody`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 [dependencies]
 bytes = "0.4"
 futures = "0.1"
-h2 = { git = "https://github.com/carllerche/h2" }
+h2 = "0.1.11"
 http = "0.1"
 log = "0.4"
 tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 [dependencies]
 bytes = "0.4"
 futures = "0.1"
-h2 = "0.1.9"
+h2 = { git = "https://github.com/carllerche/h2", branch = "eliza/expose-stream-id" }
 http = "0.1"
 log = "0.4"
 tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 [dependencies]
 bytes = "0.4"
 futures = "0.1"
-h2 = { git = "https://github.com/carllerche/h2", branch = "eliza/expose-stream-id" }
+h2 = { git = "https://github.com/carllerche/h2" }
 http = "0.1"
 log = "0.4"
 tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -191,6 +191,17 @@ impl Future for ResponseFuture {
     }
 }
 
+impl ResponseFuture {
+    /// Returns the stream ID of the response stream, or `None` if this future
+    /// does not correspond to a stream.
+    pub fn stream_id(&self) -> Option<h2::StreamId> {
+        match self.inner {
+            Inner::Inner(ref rsp) => Some(rsp.stream_id()),
+            _ => None,
+        }
+    }
+}
+
 // ===== impl Handshake =====
 
 impl<T, E, S> Handshake<T, E, S>

--- a/src/recv_body.rs
+++ b/src/recv_body.rs
@@ -8,6 +8,7 @@ use http;
 #[derive(Debug, Default)]
 pub struct RecvBody {
     inner: Option<h2::RecvStream>,
+    stream_id: h2::StreamId,
 }
 
 #[derive(Debug)]
@@ -21,7 +22,18 @@ pub struct Data {
 impl RecvBody {
     /// Return a new `RecvBody`.
     pub(crate) fn new(inner: h2::RecvStream) -> Self {
-        RecvBody { inner: Some(inner) }
+        // Get this eagerly so we still have it if the stream has closed and
+        // self.inner is None.
+        let stream_id = inner.stream_id();
+        RecvBody {
+            inner: Some(inner),
+            stream_id,
+        }
+    }
+
+    /// Returns the stream ID of the received stream.
+    pub fn stream_id(&self) -> h2::StreamId {
+        self.stream_id
     }
 }
 

--- a/src/recv_body.rs
+++ b/src/recv_body.rs
@@ -8,7 +8,6 @@ use http;
 #[derive(Debug, Default)]
 pub struct RecvBody {
     inner: Option<h2::RecvStream>,
-    stream_id: h2::StreamId,
 }
 
 #[derive(Debug)]
@@ -22,18 +21,13 @@ pub struct Data {
 impl RecvBody {
     /// Return a new `RecvBody`.
     pub(crate) fn new(inner: h2::RecvStream) -> Self {
-        // Get this eagerly so we still have it if the stream has closed and
-        // self.inner is None.
-        let stream_id = inner.stream_id();
-        RecvBody {
-            inner: Some(inner),
-            stream_id,
-        }
+        RecvBody { inner: Some(inner) }
     }
 
-    /// Returns the stream ID of the received stream.
-    pub fn stream_id(&self) -> h2::StreamId {
-        self.stream_id
+    /// Returns the stream ID of the received stream, or `None` if this body
+    /// does not correspond to a stream.
+    pub fn stream_id(&self) -> Option<h2::StreamId> {
+        self.inner.as_ref().map(h2::RecvStream::stream_id)
     }
 }
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 bytes = "0.4.7"
 futures = "0.1.21"
-h2 = { git = "https://github.com/carllerche/h2" }
+h2 = "0.1.11"
 h2-support = { git = "https://github.com/carllerche/h2" }
 http = "0.1.5"
 tokio = "0.1.5"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 [dependencies]
 bytes = "0.4.7"
 futures = "0.1.21"
-h2 = "0.1.4"
-h2-support = { git = "https://github.com/carllerche/h2" }
+h2 = { git = "https://github.com/carllerche/h2", branch = "eliza/expose-stream-id" }
+h2-support = { git = "https://github.com/carllerche/h2", branch = "eliza/expose-stream-id" }
 http = "0.1.5"
 tokio = "0.1.5"
 tower-h2 = { path = ".." }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 [dependencies]
 bytes = "0.4.7"
 futures = "0.1.21"
-h2 = { git = "https://github.com/carllerche/h2", branch = "eliza/expose-stream-id" }
-h2-support = { git = "https://github.com/carllerche/h2", branch = "eliza/expose-stream-id" }
+h2 = { git = "https://github.com/carllerche/h2" }
+h2-support = { git = "https://github.com/carllerche/h2" }
 http = "0.1.5"
 tokio = "0.1.5"
 tower-h2 = { path = ".." }


### PR DESCRIPTION
This branch adds an accessor for the stream ID to `RecvBody`. It depends on
carllerche/h2#292, and therefore currently overrides the `h2` dependency to
point at that branch. Once that branch is merged, that override will no 
longer be necessary.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>