### PR TITLE
At least log errors rather than discarding them

### DIFF
--- a/src/client/background.rs
+++ b/src/client/background.rs
@@ -51,8 +51,9 @@ where T: AsyncRead + AsyncWrite,
         use self::Task::*;
 
         match self.task {
-            // TODO: Log error?
-            Connection(ref mut f) => f.poll().map_err(|_| ()),
+            Connection(ref mut f) => f.poll().map_err(|err| {
+                warn!("error driving HTTP/2 client connection: {:?}", err);
+            }),
             Flush(ref mut f) => f.poll(),
         }
     }

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -233,7 +233,10 @@ where T: AsyncRead + AsyncWrite,
         // Spawn the worker task
         let task = Background::connection(connection);
         self.executor.execute(task)
-            .map_err(|_| HandshakeError::Execute)?;
+            .map_err(|err| {
+                warn!("error handshaking: {:?}", err);
+                HandshakeError::Execute
+            })?;
 
         // Create an instance of the service
         let service = Connection::new(client, self.executor.clone());

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -167,7 +167,8 @@ where S: Body,
     type Error = ();
 
     fn poll(&mut self) -> Poll<(), ()> {
-        // TODO: Do something with the error
-        self.poll_complete().map_err(|_| ())
+        self.poll_complete().map_err(|err| {
+            warn!("error flushing stream: {:?}", err)
+        })
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -450,8 +450,8 @@ where T: Future<Item = Response<B>>,
                             // Transition to flushing the body
                             Flush::new(body, stream)
                         }
-                        Err(_) => {
-                            // TODO: Do something with the error?
+                        Err(err) => {
+                            warn!("error sending response: {:?}", err);
                             return Ok(().into());
                         }
                     }


### PR DESCRIPTION
This is a *preliminary* solution to issue #37, which lists cases where
errors aren't well-handled. Rather than silently logging these errors,
this branch adds log statements to log them at the `warn` level.

It seems like there are at least some cases where we ought to do more
than just log these errors, such as returning them. However, logging
these errors seems like a reasonable stopgap until we can add better
error handling in these cases.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>