### PR TITLE
Add more integration tests

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -11,6 +11,7 @@ h2 = "0.1.11"
 h2-support = { git = "https://github.com/carllerche/h2" }
 http = "0.1.5"
 tokio = "0.1.7"
+tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
 tower-h2 = { path = ".." }
 tower-service = { git = "https://github.com/tower-rs/tower" }
 tower-util = { git = "https://github.com/tower-rs/tower" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -10,7 +10,8 @@ futures = "0.1.21"
 h2 = "0.1.11"
 h2-support = { git = "https://github.com/carllerche/h2" }
 http = "0.1.5"
-tokio = "0.1.7"
+tokio = "0.1.8"
+tokio-current-thread = "0.1.1"
 tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
 tower-h2 = { path = ".." }
 tower-service = { git = "https://github.com/tower-rs/tower" }

--- a/tests/tests/client.rs
+++ b/tests/tests/client.rs
@@ -89,7 +89,7 @@ fn hello_req_body() {
             frames::headers(1)
                 .request("GET", "https://example.com/")
         )
-        .recv_frame(frames::data(1, "hello world"))
+        .recv_frame(frames::data(1, "hello world").eos())
         .send_frame(frames::headers(1).response(200).eos())
         .close();
 
@@ -175,7 +175,7 @@ fn hello_bodies() {
             frames::headers(1)
                 .request("GET", "https://example.com/")
         )
-        .recv_frame(frames::data(1, "hello world"))
+        .recv_frame(frames::data(1, "hello world").eos())
         .send_frame(frames::headers(1).response(200))
         .send_frame(frames::data(1, "hello"))
         .send_frame(frames::data(1, " back!").eos())

--- a/tests/tests/client.rs
+++ b/tests/tests/client.rs
@@ -71,8 +71,7 @@ fn hello() {
 
     Runtime::new()
         .unwrap()
-        .spawn(srv)
-        .block_on(done)
+        .block_on(done.join(srv))
         .unwrap();
 }
 
@@ -113,8 +112,7 @@ fn hello_req_body() {
 
     Runtime::new()
         .unwrap()
-        .spawn(srv)
-        .block_on(done)
+        .block_on(done.join(srv))
         .unwrap();
 }
 
@@ -159,8 +157,7 @@ fn hello_rsp_body() {
 
     Runtime::new()
         .unwrap()
-        .spawn(srv)
-        .block_on(done)
+        .block_on(done.join(srv))
         .unwrap();
 }
 
@@ -206,7 +203,6 @@ fn hello_bodies() {
 
     Runtime::new()
         .unwrap()
-        .spawn(srv)
-        .block_on(done)
+        .block_on(done.join(srv))
         .unwrap();
 }

--- a/tests/tests/client.rs
+++ b/tests/tests/client.rs
@@ -2,8 +2,8 @@ use self::support::*;
 extern crate tokio_connect;
 
 use h2_support::{mock::Mock, prelude::*};
-use tokio::executor::current_thread::*;
-
+use tokio::runtime::current_thread::Runtime;
+use tokio_current_thread::TaskExecutor;
 use tower_h2::client::Connect;
 
 use tower_service::{NewService, Service};
@@ -44,6 +44,7 @@ fn hello() {
         .assert_client_handshake()
         .unwrap()
         .recv_settings()
+        .recv_frame(frames::data(9000, "barf"))
         .recv_frame(
             frames::headers(1)
                 .request("GET", "https://example.com/")
@@ -69,7 +70,8 @@ fn hello() {
         })
         .map_err(|e| panic!("error: {:?}", e));
 
-    CurrentThread::new()
+    Runtime::new()
+        .unwrap()
         .spawn(srv)
         .block_on(done)
         .unwrap();
@@ -110,7 +112,8 @@ fn hello_req_body() {
         })
         .map_err(|e| panic!("error: {:?}", e));
 
-    CurrentThread::new()
+    Runtime::new()
+        .unwrap()
         .spawn(srv)
         .block_on(done)
         .unwrap();
@@ -155,7 +158,8 @@ fn hello_rsp_body() {
         .map(|body| assert_eq!(body, Some("hello world".into())))
         .map_err(|e| panic!("error: {:?}", e));
 
-    CurrentThread::new()
+    Runtime::new()
+        .unwrap()
         .spawn(srv)
         .block_on(done)
         .unwrap();
@@ -201,7 +205,8 @@ fn hello_bodies() {
         .map(|body| assert_eq!(body, Some("hello back!".into())))
         .map_err(|e| panic!("error: {:?}", e));
 
-    CurrentThread::new()
+    Runtime::new()
+        .unwrap()
         .spawn(srv)
         .block_on(done)
         .unwrap();

--- a/tests/tests/client.rs
+++ b/tests/tests/client.rs
@@ -1,0 +1,76 @@
+use self::support::*;
+extern crate tokio_connect;
+
+use h2_support::{mock::Mock, prelude::*};
+use tokio::executor::current_thread::*;
+
+use tower_h2::client::Connect;
+
+use tower_service::{NewService, Service};
+use futures::future::{self, FutureResult};
+use std::cell::RefCell;
+
+mod support;
+
+struct MockConn {
+    conn: RefCell<Option<Mock>>,
+}
+
+impl MockConn {
+    fn new(mock: Mock) -> Self {
+        MockConn {
+            conn: RefCell::new(Some(mock))
+        }
+    }
+}
+
+impl tokio_connect::Connect for MockConn {
+    type Connected = Mock;
+    type Error = ::std::io::Error;
+    type Future = FutureResult<Mock, ::std::io::Error>;
+
+    fn connect(&self) -> Self::Future {
+        future::ok(self.conn.borrow_mut().take().expect("connected more than once!"))
+    }
+}
+
+#[test]
+fn hello() {
+    let _ = ::env_logger::try_init();
+
+    let (io, srv) = mock::new();
+
+    let srv = srv
+        .assert_client_handshake()
+        .unwrap()
+        .recv_settings()
+        .recv_frame(
+            frames::headers(1)
+                .request("GET", "https://example.com/")
+                .eos(),
+        )
+        .send_frame(frames::headers(1).response(200).eos())
+        .close();
+
+    let conn = MockConn::new(io);
+    let h2 = Connect::new(conn, Default::default(), TaskExecutor::current());
+
+    let done = h2.new_service()
+        .map_err(|e| panic!("connect err: {:?}", e))
+        .and_then(|mut h2| {
+            h2.call(http::Request::builder()
+                .method("GET")
+                .uri("https://example.com/")
+                .body(())
+                .unwrap())
+        })
+        .map(|rsp| {
+            assert_eq!(rsp.status(), http::StatusCode::OK);
+        })
+        .map_err(|e| panic!("error: {:?}", e));
+
+    CurrentThread::new()
+        .spawn(srv)
+        .block_on(done)
+        .unwrap();
+}

--- a/tests/tests/client.rs
+++ b/tests/tests/client.rs
@@ -44,7 +44,6 @@ fn hello() {
         .assert_client_handshake()
         .unwrap()
         .recv_settings()
-        .recv_frame(frames::data(9000, "barf"))
         .recv_frame(
             frames::headers(1)
                 .request("GET", "https://example.com/")

--- a/tests/tests/server.rs
+++ b/tests/tests/server.rs
@@ -2,7 +2,8 @@ use self::support::*;
 
 use bytes::Bytes;
 use h2_support::prelude::*;
-use tokio::executor::current_thread::*;
+use tokio::runtime::current_thread::Runtime;
+use tokio_current_thread::TaskExecutor;
 use tower_h2::Body;
 use tower_h2::server::Server;
 
@@ -110,7 +111,8 @@ fn hello() {
         }),
         Default::default(), TaskExecutor::current());
 
-    CurrentThread::new()
+    Runtime::new()
+        .unwrap()
         .spawn(h2.serve(io).map_err(|e| panic!("err={:?}", e)))
         .block_on(client)
         .unwrap();
@@ -154,7 +156,8 @@ fn hello_bodies() {
         }),
         Default::default(), TaskExecutor::current());
 
-    CurrentThread::new()
+    Runtime::new()
+        .unwrap()
         .spawn(h2.serve(io).map_err(|e| panic!("err={:?}", e)))
         .block_on(client)
         .unwrap();
@@ -191,7 +194,8 @@ fn hello_rsp_body() {
         }),
         Default::default(), TaskExecutor::current());
 
-    CurrentThread::new()
+    Runtime::new()
+        .unwrap()
         .spawn(h2.serve(io).map_err(|e| panic!("err={:?}", e)))
         .block_on(client)
         .unwrap();
@@ -232,7 +236,8 @@ fn hello_req_body() {
         }),
         Default::default(), TaskExecutor::current());
 
-    CurrentThread::new()
+    Runtime::new()
+        .unwrap()
         .spawn(h2.serve(io).map_err(|e| panic!("err={:?}", e)))
         .block_on(client)
         .unwrap();
@@ -326,7 +331,8 @@ fn respects_flow_control_eos_signal() {
         }),
         Default::default(), TaskExecutor::current());
 
-    CurrentThread::new()
+    Runtime::new()
+        .unwrap()
         .spawn(h2.serve(io).map_err(|e| panic!("err={:?}", e)))
         .block_on(client)
         .unwrap();
@@ -417,7 +423,8 @@ fn respects_flow_control_no_eos_signal() {
         }),
         Default::default(), TaskExecutor::current());
 
-    CurrentThread::new()
+    Runtime::new()
+        .unwrap()
         .spawn(h2.serve(io).map_err(|e| panic!("err={:?}", e)))
         .block_on(client)
         .unwrap();
@@ -508,7 +515,7 @@ fn flushing_body_cancels_if_reset() {
 
     // hold on to the runtime so that after block_on, it isn't dropped
     // immediately, which defeats our test.
-    let mut rt = CurrentThread::new();
+    let mut rt = Runtime::new().unwrap();
     rt.spawn(h2.serve(io).map_err(|e| panic!("err={:?}", e)));
     rt.block_on(client).unwrap();
 

--- a/tests/tests/server.rs
+++ b/tests/tests/server.rs
@@ -111,10 +111,10 @@ fn hello() {
         }),
         Default::default(), TaskExecutor::current());
 
+    let f = h2.serve(io).map_err(|e| panic!("err={:?}", e)).join(client);
     Runtime::new()
         .unwrap()
-        .spawn(h2.serve(io).map_err(|e| panic!("err={:?}", e)))
-        .block_on(client)
+        .block_on(f)
         .unwrap();
 }
 
@@ -156,10 +156,10 @@ fn hello_bodies() {
         }),
         Default::default(), TaskExecutor::current());
 
+    let f = h2.serve(io).map_err(|e| panic!("err={:?}", e)).join(client);
     Runtime::new()
         .unwrap()
-        .spawn(h2.serve(io).map_err(|e| panic!("err={:?}", e)))
-        .block_on(client)
+        .block_on(f)
         .unwrap();
 }
 
@@ -194,10 +194,10 @@ fn hello_rsp_body() {
         }),
         Default::default(), TaskExecutor::current());
 
+    let f = h2.serve(io).map_err(|e| panic!("err={:?}", e)).join(client);
     Runtime::new()
         .unwrap()
-        .spawn(h2.serve(io).map_err(|e| panic!("err={:?}", e)))
-        .block_on(client)
+        .block_on(f)
         .unwrap();
 }
 
@@ -236,10 +236,10 @@ fn hello_req_body() {
         }),
         Default::default(), TaskExecutor::current());
 
+    let f = h2.serve(io).map_err(|e| panic!("err={:?}", e)).join(client);
     Runtime::new()
         .unwrap()
-        .spawn(h2.serve(io).map_err(|e| panic!("err={:?}", e)))
-        .block_on(client)
+        .block_on(f)
         .unwrap();
 }
 
@@ -331,10 +331,10 @@ fn respects_flow_control_eos_signal() {
         }),
         Default::default(), TaskExecutor::current());
 
+    let f = h2.serve(io).map_err(|e| panic!("err={:?}", e)).join(client);
     Runtime::new()
         .unwrap()
-        .spawn(h2.serve(io).map_err(|e| panic!("err={:?}", e)))
-        .block_on(client)
+        .block_on(f)
         .unwrap();
 }
 
@@ -423,10 +423,10 @@ fn respects_flow_control_no_eos_signal() {
         }),
         Default::default(), TaskExecutor::current());
 
+    let f = h2.serve(io).map_err(|e| panic!("err={:?}", e)).join(client);
     Runtime::new()
         .unwrap()
-        .spawn(h2.serve(io).map_err(|e| panic!("err={:?}", e)))
-        .block_on(client)
+        .block_on(f)
         .unwrap();
 }
 
@@ -516,8 +516,8 @@ fn flushing_body_cancels_if_reset() {
     // hold on to the runtime so that after block_on, it isn't dropped
     // immediately, which defeats our test.
     let mut rt = Runtime::new().unwrap();
-    rt.spawn(h2.serve(io).map_err(|e| panic!("err={:?}", e)));
-    rt.block_on(client).unwrap();
+    let f = h2.serve(io).map_err(|e| panic!("err={:?}", e)).join(client);
+    rt.block_on(f).unwrap();
 
     // The flush future should have finished, since it was reset. If so,
     // it will have dropped once.

--- a/tests/tests/server.rs
+++ b/tests/tests/server.rs
@@ -147,7 +147,7 @@ fn hello_bodies() {
 
                     let response = http::Response::builder()
                         .status(200)
-                        .body(RspBody::new("hello back".into()))
+                        .body(SendBody::new("hello back"))
                         .unwrap();
                     Ok(response)
                 })
@@ -184,7 +184,7 @@ fn hello_rsp_body() {
         SyncServiceFn::new(|_req| {
             let response = http::Response::builder()
                 .status(200)
-                .body(RspBody::new("hello back".into()))
+                .body(SendBody::new("hello back"))
                 .unwrap();
 
             Ok::<_, ()>(response.into())

--- a/tests/tests/server.rs
+++ b/tests/tests/server.rs
@@ -135,7 +135,7 @@ fn hello_bodies() {
         )
         .recv_frame(frames::headers(1).response(200))
 
-        .recv_frame(frames::data(1, "hello back"))
+        .recv_frame(frames::data(1, "hello back").eos())
         .close();
 
     let h2 = Server::new(
@@ -177,7 +177,7 @@ fn hello_rsp_body() {
                 .eos()
         )
         .recv_frame(frames::headers(1).response(200))
-        .recv_frame(frames::data(1, "hello back"))
+        .recv_frame(frames::data(1, "hello back").eos())
         .close();
 
     let h2 = Server::new(

--- a/tests/tests/support.rs
+++ b/tests/tests/support.rs
@@ -40,7 +40,7 @@ impl Body for SendBody {
     type Data = Bytes;
 
     fn is_end_stream(&self) -> bool {
-        self.0.as_ref().map(|b| b.is_empty()).unwrap_or(false)
+        self.0.as_ref().map(|b| b.is_empty()).unwrap_or(true)
     }
 
     fn poll_data(&mut self) -> Poll<Option<Bytes>, h2::Error> {

--- a/tests/tests/support.rs
+++ b/tests/tests/support.rs
@@ -1,0 +1,81 @@
+pub extern crate bytes;
+pub extern crate futures;
+pub extern crate h2;
+pub extern crate h2_support;
+pub extern crate http;
+pub extern crate tokio;
+pub extern crate tower_h2;
+pub extern crate tower_service;
+pub extern crate tower_util;
+
+use bytes::{Bytes, Buf};
+use tower_h2::{Body, RecvBody};
+use futures::{Future, Poll, Async};
+
+// We can't import `try_ready` here because this module isn't at the crate
+// root, so we'll redefine it instead.
+#[macro_export]
+macro_rules! try_ready {
+    ($e:expr) => (match $e {
+        Ok(futures::Async::Ready(t)) => t,
+        Ok(futures::Async::NotReady) =>
+            return Ok(futures::Async::NotReady),
+        Err(e) => return Err(From::from(e)),
+    })
+}
+
+pub struct RspBody(Option<Bytes>);
+
+impl RspBody {
+    pub fn new(body: Bytes) -> Self {
+        RspBody(Some(body))
+    }
+
+    pub fn empty() -> Self {
+        RspBody(None)
+    }
+}
+
+impl Body for RspBody {
+    type Data = Bytes;
+
+    fn is_end_stream(&self) -> bool {
+        self.0.as_ref().map(|b| b.is_empty()).unwrap_or(false)
+    }
+
+    fn poll_data(&mut self) -> Poll<Option<Bytes>, h2::Error> {
+        let data = self.0
+            .take()
+            .and_then(|b| if b.is_empty() { None } else { Some(b) });
+        Ok(Async::Ready(data))
+    }
+}
+
+
+pub fn read_recv_body(body: RecvBody) -> ReadRecvBody {
+    ReadRecvBody {
+        body,
+        bytes: None,
+    }
+}
+pub struct ReadRecvBody {
+    body: RecvBody,
+    bytes: Option<Box<Buf>>,
+}
+
+impl Future for ReadRecvBody {
+    type Item = Option<Bytes>;
+    type Error = self::h2::Error;
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        loop {
+            self.bytes = match try_ready!(self.body.poll_data()) {
+                None => return Ok(Async::Ready(self.bytes.take().map(Buf::collect))),
+                Some(b) => if self.bytes.as_ref().is_none() {
+                    Some(Box::new(b))
+                } else {
+                    Some(Box::new(self.bytes.take().unwrap().chain(b)))
+                },
+            }
+        }
+    }
+}

--- a/tests/tests/support.rs
+++ b/tests/tests/support.rs
@@ -24,19 +24,19 @@ macro_rules! try_ready {
     })
 }
 
-pub struct RspBody(Option<Bytes>);
+pub struct SendBody(Option<Bytes>);
 
-impl RspBody {
-    pub fn new(body: Bytes) -> Self {
-        RspBody(Some(body))
+impl SendBody {
+    pub fn new<I: Into<Bytes>>(body: I) -> Self {
+        SendBody(Some(body.into()))
     }
 
     pub fn empty() -> Self {
-        RspBody(None)
+        SendBody(None)
     }
 }
 
-impl Body for RspBody {
+impl Body for SendBody {
     type Data = Bytes;
 
     fn is_end_stream(&self) -> bool {

--- a/tests/tests/support.rs
+++ b/tests/tests/support.rs
@@ -4,6 +4,7 @@ pub extern crate h2;
 pub extern crate h2_support;
 pub extern crate http;
 pub extern crate tokio;
+pub extern crate tokio_current_thread;
 pub extern crate tower_h2;
 pub extern crate tower_service;
 pub extern crate tower_util;


### PR DESCRIPTION
This branch begins adding additional integration tests. In particular,
it adds the following:
 - Additional "hello world" integration tests with request bodies,
   response bodies, and request and response bodies,
 - A `tests/client.rs` module to contain tests for "real" clients with
   mocked-out servers, and,
- A `tests/support.rs` module containing utility code factored out of
  the server tests, which are used in both sets of tests.

I plan to add additional tests in subsequent PRs, but I thought it 
would be best to get these changes merged now.

Test coverage (as reported by [tarpaulin]):
------------------------------------------

Before:
```
$ cargo tarpaulin -p tests --exclude-files tests/* --exclude-files tower-balance/*

Coverage Results
Tested/Total Lines:
src/body.rs: 4/28
src/buf.rs: 13/15
src/client/background.rs: 0/8
src/client/connect.rs: 0/34
src/client/connection.rs: 0/95
src/flush.rs: 35/55
src/recv_body.rs: 2/44
src/server/mod.rs: 57/158
src/service.rs: 0/14

24.61% coverage, 111/451 lines covered
Tarpaulin finished
```

After:
```
$ cargo tarpaulin -p tests --exclude-files tests/* --exclude-files tower-balance/*

Coverage Results
Tested/Total Lines:
src/body.rs: 4/28
src/buf.rs: 13/15
src/client/background.rs: 8/8
src/client/connect.rs: 16/34
src/client/connection.rs: 28/95
src/flush.rs: 35/55
src/recv_body.rs: 24/44
src/server/mod.rs: 57/158
src/service.rs: 0/14

41.02% coverage, 185/451 lines covered
Tarpaulin finished
```

Coverage diff: +16.41%

[tarpaulin]: https://github.com/xd009642/tarpaulin

Signed-off-by: Eliza Weisman <eliza@buoyant.io>