### PR TITLE
Ensure Server::new creates usable instances

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -120,8 +120,11 @@ enum PollMain {
 // ===== impl Server =====
 
 impl<S, E, B> Server<S, E, B>
-where S: MakeService<(), Request<RecvBody>, Response = Response<B>>,
-      B: Body,
+where
+    S: MakeService<(), Request<RecvBody>, Response = Response<B>>,
+    B: Body + 'static,
+    E: Clone
+        + Executor<Background<<S::Service as Service<Request<RecvBody>>>::Future, B>>,
 {
     pub fn new(new_service: S, builder: h2::server::Builder, executor: E) -> Self {
         Server {


### PR DESCRIPTION
Impose trait bounds on type parameters of `Server::new` to ensure
that a `Connection` served by the server satisfies the bounds to implement
`Future`.

Fixes #43.