### PR TITLE
Expose Handshake::new for use with custom Builders

### DIFF
--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -208,7 +208,7 @@ where T: AsyncRead + AsyncWrite,
       S: Body,
 {
     /// Start an HTTP/2.0 handshake with the provided builder
-    pub(crate) fn new(io: T, executor: E, builder: &Builder) -> Self {
+    pub fn new(io: T, executor: E, builder: &Builder) -> Self {
         let inner = builder.handshake(io);
 
         Handshake {


### PR DESCRIPTION
### Changed

* Make `Handshake::new()` constructor `pub` so users can specify custom builders.

I was following the steps described in tower-rs/tower-grpc#75 to improve the binary stream transfer rates of `tower-grpc`, but I ran into the same issue @gwihlidal had ran into where `tower-h2::client::Handshake` didn't have a public constructor to pass in a custom `Builder` with the correct window sizes.

I'm not exactly sure if exposing the `new()` constructor here is enough, or if we should expose it in the underlying `h2::client::Handshake` type as well for consistency. I would be happy to hear any thoughts on this.