### PR TITLE
Add ConnectService and remove tokio_connect::Connect

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -18,7 +18,7 @@ use string::{String, TryFrom};
 use tokio::net::TcpStream;
 use tokio::runtime::{Runtime, TaskExecutor};
 use tower_h2::{Body, RecvBody};
-use tower_h2::client::Connect;
+use tower_h2::client::{Connect, ConnectService};
 use tower_service::Service;
 use tower_util::MakeService;
 use h2::Reason;
@@ -33,10 +33,10 @@ fn main() {
 
     let addr = "[::1]:8888".parse().unwrap();
 
-    impl tokio_connect::Connect for Conn {
-        type Connected = TcpStream;
-        type Error = ::std::io::Error;
-        type Future = Box<Future<Item = TcpStream, Error = ::std::io::Error> + Send>;
+    impl ConnectService<SocketAddr> for Conn {
+        type Response = TcpStream;
+        type Error = std::io::Error;
+        type Future = Box<Future<Item = TcpStream, Error = std::io::Error> + Send>;
 
         fn connect(&self) -> Self::Future {
             let c = TcpStream::connect(&self.0)

--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -33,7 +33,7 @@ pub struct Connect<A, C, E, S> {
 
 /// Completes with a Connection when the H2 connection has been initialized.
 pub struct ConnectFuture<A, C, E, S>
-where 
+where
     C: ConnectService<A>,
     S: Body,
 {
@@ -95,7 +95,7 @@ where
     }
 }
 
-impl<A, C, E, S> Service<()> for Connect<A, C, E, S>
+impl<A, C, E, S> Service<A> for Connect<A, C, E, S>
 where
     C: ConnectService<A> + 'static,
     E: Executor<Background<C::Response, S>> + Clone,
@@ -110,8 +110,8 @@ where
     }
 
     /// Obtains a Connection on a single plaintext h2 connection to a remote.
-    fn call(&mut self, _target: ()) -> Self::Future {
-        let state = State::Connect(self.inner.connect());
+    fn call(&mut self, target: A) -> Self::Future {
+        let state = State::Connect(self.inner.connect(target));
         let builder = self.builder.clone();
 
         ConnectFuture {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,7 +1,9 @@
 mod background;
 mod connect;
 mod connection;
+mod util;
 
 pub use self::background::Background;
 pub use self::connect::{Connect, ConnectFuture, ConnectError};
 pub use self::connection::{Connection, Handshake, ResponseFuture, Error, HandshakeError};
+pub use self::util::ConnectService;

--- a/src/client/util.rs
+++ b/src/client/util.rs
@@ -1,0 +1,27 @@
+use tower_service::Service;
+use futures::Future;
+use tokio_io::{AsyncRead, AsyncWrite};
+
+pub trait ConnectService<A>{
+    type Response: AsyncRead + AsyncWrite;
+    type Error;
+    type Future: Future<Item =  Self::Response, Error = Self::Error>;
+
+    fn connect(&self) -> Self::Future;
+}
+
+impl<A, C> ConnectService<A> for C
+    where C: Service<A>,
+          C::Response: AsyncRead + AsyncWrite,
+{
+    type Response = C::Response;
+    type Error = C::Error;
+    type Future = C::Future;
+
+    // TODO: don't quite know why I need to suppress this, doesn't seem
+    // like it's needed for MakeService. 
+    #[allow(unconditional_recursion)]
+    fn connect(&self) -> Self::Future {
+        ConnectService::connect(self)
+    }
+}

--- a/src/client/util.rs
+++ b/src/client/util.rs
@@ -7,21 +7,19 @@ pub trait ConnectService<A>{
     type Error;
     type Future: Future<Item =  Self::Response, Error = Self::Error>;
 
-    fn connect(&self) -> Self::Future;
+    fn connect(&mut self, target: A) -> Self::Future;
 }
 
 impl<A, C> ConnectService<A> for C
-    where C: Service<A>,
-          C::Response: AsyncRead + AsyncWrite,
+where 
+    C: Service<A>,
+    C::Response: AsyncRead + AsyncWrite,
 {
     type Response = C::Response;
     type Error = C::Error;
     type Future = C::Future;
 
-    // TODO: don't quite know why I need to suppress this, doesn't seem
-    // like it's needed for MakeService. 
-    #[allow(unconditional_recursion)]
-    fn connect(&self) -> Self::Future {
-        ConnectService::connect(self)
+    fn connect(&mut self, target: A) -> Self::Future {
+        self.call(target)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@ extern crate h2;
 extern crate http;
 #[macro_use]
 extern crate log;
-extern crate tokio_connect;
 extern crate tokio_io;
 extern crate tower_service;
 extern crate tower_util;

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -12,7 +12,6 @@ h2-support = { git = "https://github.com/carllerche/h2" }
 http = "0.1.5"
 tokio = "0.1.8"
 tokio-current-thread = "0.1.1"
-tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
 tower-h2 = { path = ".." }
 tower-service = { git = "https://github.com/tower-rs/tower" }
 tower-util = { git = "https://github.com/tower-rs/tower"  }

--- a/tests/tests/client.rs
+++ b/tests/tests/client.rs
@@ -1,10 +1,9 @@
 use self::support::*;
-extern crate tokio_connect;
 
 use h2_support::{mock::Mock, prelude::*};
 use tokio::runtime::current_thread::Runtime;
 use tokio_current_thread::TaskExecutor;
-use tower_h2::client::Connect;
+use tower_h2::client::{Connect, ConnectService};
 
 use tower_service::Service;
 use tower_util::MakeService;
@@ -25,10 +24,10 @@ impl MockConn {
     }
 }
 
-impl tokio_connect::Connect for MockConn {
-    type Connected = Mock;
-    type Error = ::std::io::Error;
-    type Future = FutureResult<Mock, ::std::io::Error>;
+impl ConnectService<()> for MockConn {
+    type Response = Mock;
+    type Error = std::io::Error;
+    type Future = FutureResult<Mock, std::io::Error>;
 
     fn connect(&self) -> Self::Future {
         future::ok(self.conn.borrow_mut().take().expect("connected more than once!"))

--- a/tests/tests/client.rs
+++ b/tests/tests/client.rs
@@ -29,7 +29,7 @@ impl ConnectService<()> for MockConn {
     type Error = std::io::Error;
     type Future = FutureResult<Mock, std::io::Error>;
 
-    fn connect(&self) -> Self::Future {
+    fn connect(&mut self, _target: ()) -> Self::Future {
         future::ok(self.conn.borrow_mut().take().expect("connected more than once!"))
     }
 }


### PR DESCRIPTION
This change adds an initial implementation of a ConnectService trait alias that allows for the Connect phase to be abstracted away as a service. Currently, the address supplied to the underlying service is open so this leaves room for additional ways to "connect" to a service.

cc @carllerche 