### PR TITLE
Update tower-http-service for tower-h2-balance

### DIFF
--- a/tower-balance/Cargo.toml
+++ b/tower-balance/Cargo.toml
@@ -6,9 +6,9 @@ authors = ["Oliver Gould <ver@buoyant.io>"]
 [dependencies]
 futures = "0.1"
 http = "0.1"
-h2 = "0.1"
 
-tower-h2  = { version = "0.1", path = ".." }
+tokio-buf = "0.1"
+tower-http-service = { git = "https://github.com/tower-rs/tower-http" }
 
 tower-balance = { git = "https://github.com/tower-rs/tower" }
 tower-service = "0.2"


### PR DESCRIPTION
This crate is now not dependent `tower-h2`, we should rename it to `tower-http-balance` and move to `tower-http`?